### PR TITLE
Fix rotate method on RotateComp

### DIFF
--- a/boom/components/rotate.lua
+++ b/boom/components/rotate.lua
@@ -21,7 +21,7 @@ function M.rotate(angle)
 		update_rotation(c.object)
 	end
 	c.rotate = function(angle)
-		c.angle = angle
+		c.object.angle = angle
 		update_rotation(c.object)
 	end
 


### PR DESCRIPTION
Currently the `rotate` function does not properly apply the `angle` argument. This change fixes that behavior.

Lua code I used to test the issue:

```lua
local player = add({
 sprite("sprite"),
 pos(120, 80),
 rotate(0),
 anchor("center")
})
on_update(function(_cancel)
 player.rotate(player.angle - 120 * dt())
end)
```